### PR TITLE
forzar el render para mostrar las bolillas marcadas

### DIFF
--- a/src/pages/lobbies/_lobbyId/play/UserProgress.js
+++ b/src/pages/lobbies/_lobbyId/play/UserProgress.js
@@ -1,10 +1,13 @@
 import React, { useState } from "reactn";
-import { firestore } from "../../../../firebase";
 import { darkTheme } from "../../../../theme";
 import { Progress } from "antd";
+import { useMemo } from "react";
 
 export const UserProgress = (props) => {
-  const [numberWinners] = useState(props.user.myWinningCard ?? props.numberWinners);
+  const numberWinners = useMemo(() => {
+    return props.user.myWinningCard ?? props.numberWinners;
+  }, [props.user.myWinningCard, props.numberWinners]);
+
   const [userCard] = useState(JSON.parse(props.user.card));
 
   return props.isCard ? (


### PR DESCRIPTION
Tras el ultimo cambio se perdio la vista previa en tiempo real de las bolillas marcadas, se ha usado useMemo para actualizar los datos cada vez que el usuario marca una bolilla